### PR TITLE
Add HTML parsing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+**/__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ This project showcases a 3D model of an American semi-truck and trailer using th
 
 1. Ensure your computer is connected to the internet so the Three.js CDN can be loaded.
 2. Open `american-truck-3d.html` in a modern web browser.
+
+## Testing
+
+Run the unit tests with [pytest](https://pytest.org):
+
+```bash
+pytest
+```

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,20 @@
+import pathlib
+
+
+def test_html_parses_without_errors():
+    html_path = pathlib.Path(__file__).resolve().parents[1] / "american-truck-3d.html"
+    html_content = html_path.read_text(encoding="utf-8")
+
+    try:
+        from bs4 import BeautifulSoup
+        BeautifulSoup(html_content, "html.parser")
+    except ImportError:
+        from html.parser import HTMLParser
+
+        class Parser(HTMLParser):
+            """Simple HTML parser that ignores the content."""
+            pass
+
+        parser = Parser()
+        parser.feed(html_content)
+


### PR DESCRIPTION
## Summary
- ensure pytest caches and bytecode are ignored
- add a basic test that parses `american-truck-3d.html`
- describe how to run the test in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850671171e4832d8509b5d01eec197a